### PR TITLE
tests and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ You can also install ephembot globally or `npm link` from inside the repo and
 run `ephembot -p 4000` which will run it on port 4000. Choose whatever port you
 want.
 
+[![js-standard-style](https://raw.githubusercontent.com/feross/standard/master/badge.png)](https://github.com/feross/standard)

--- a/index.js
+++ b/index.js
@@ -1,9 +1,39 @@
 'use strict'
 
 import http from 'http'
+import finalhandler from 'finalhandler'
+import Router from 'router'
+import commands from './lib/commands'
+import _ from 'lodash-fp'
+import parseBody from 'body-parser'
 
-var app = http.createServer(function(req, res) {
-  req.pipe(res)
+var router = Router()
+
+/**
+ * This route should be given to slack as the endpoint to which to send
+ * `/ephemeral` data.
+ */
+router.post('/ephemeral', parseBody(), function (req, res) {
+  // grab the payload.
+  var command = req.body
+
+  // assume failure.
+  res.statusCode = 400
+
+  // Grab the function based on command name and run it if it exists
+  var run = commands[command.text]
+  if (command.command === '/ephemeral' && run) {
+    // everything is good, let the client know.
+    res.statusCode = 200
+    run(command)
+  }
+
+  // end response
+  res.end()
+})
+
+var app = http.createServer(function (req, res) {
+  router(req, res, finalhandler(req, res))
 })
 
 export default app

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,0 +1,5 @@
+export default {
+  'on': function (cmd) {},
+  'off': function (cmd) {},
+  'level': function (cmd) {}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ephemeral-enforcer",
   "version": "1.0.0",
+  "engines": {
+    "iojs": "^1.6.0"
+  },
   "description": "A lil' slack bot that'll make slack more ephemeral",
   "main": "bin/ephembot.js",
   "bin": {
@@ -8,7 +11,7 @@
   },
   "scripts": {
     "start": "./bin/ephembot",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "standard && mocha tests/index.js",
     "build:dist": "./bin/dist.js",
     "build:dev": "./bin/dev.js"
   },
@@ -27,10 +30,16 @@
   "homepage": "https://github.com/Denver-Devs/ephemeral-enforcer",
   "devDependencies": {
     "chai": "^2.2.0",
-    "mocha": "^2.2.1"
+    "mocha": "^2.2.1",
+    "standard": "^3.3.0",
+    "supertest": "^0.15.0"
   },
   "dependencies": {
     "babel": "^4.7.16",
-    "minimist": "^1.1.1"
+    "body-parser": "^1.12.2",
+    "finalhandler": "^0.3.4",
+    "lodash-fp": "^0.5.1",
+    "minimist": "^1.1.1",
+    "router": "^1.0.0"
   }
 }

--- a/tests/endpoints.test.js
+++ b/tests/endpoints.test.js
@@ -1,0 +1,26 @@
+/* global describe it */
+
+require('babel/register')
+
+var app = require('../')
+var request = require('supertest')(app)
+
+describe('/ephemeral', function () {
+  it('should respond 200 to supported commands', function (done) {
+    request
+      .post('/ephemeral')
+      // .set('Content-Type', 'application/json')
+      // .set('Accept', 'application/json')
+      .send({command: '/ephemeral', text: 'on'})
+      .expect(200, done)
+  })
+
+  it('should respond 400 to unsupported commands', function (done) {
+    request
+      .post('/ephemeral')
+      // .set('Content-Type', 'application/json')
+      // .set('Accept', 'application/json')
+      .send({command: '/ephemeral', text: 'butts'})
+      .expect(400, done)
+  })
+})

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,7 @@
+// Enable ES6
+require('babel/register')
+
+/**
+ * Require enabled tests here.
+ */
+require('./endpoints.test')


### PR DESCRIPTION
+ +babel
+ +standard
+ +`/ephemeral` `POST` endpoint

Using https://api.slack.com/slash-commands I implemented a `POST` endpoint that validates requests based on if they are of the type `/ephemeral` and if the desired command has been implemented. Implemented commands are checked by trying to access them by name from the `lib/commands.js` object. So this endpoint should scale as that may.

### Example usage:
On slack type `/ephemeral on` and this will run the `on` function defined in `lib/commands.js`.

This still needs to wire up a response to the slack user that runs the command but I will have to see how our commands flesh out in order to decide the best route for that.