### PR TITLE
Add 'inclusive' to get_history spec

### DIFF
--- a/test/fixture/history.json
+++ b/test/fixture/history.json
@@ -1,6 +1,5 @@
 {
   "ok": true,
-  "latest": "1358547726.000022",
   "messages": [
     {
       "type": "message",

--- a/test/spec/get_history.test.js
+++ b/test/spec/get_history.test.js
@@ -11,17 +11,18 @@ const opts = {
   token: 'foo',
   channel: 'bar',
   count: 10,
+  inclusive: 1,
   latest: 1358546515
 }
 
-let first = '/api/channels.history?token=foo&channel=bar&count=10&latest=1358546515'
+let first = '/api/channels.history?token=foo&channel=bar&count=10&inclusive=1&latest=1358546515'
 let firstRes = {
   ok: true,
   has_more: true,
   messages: messages.slice(0, 10)
 }
 
-let second = '/api/channels.history?token=foo&channel=bar&count=10&latest=1358546515.000011'
+let second = '/api/channels.history?token=foo&channel=bar&count=10&inclusive=1&latest=1358546515.000011'
 let secondRes = {
   ok: true,
   has_more: false,


### PR DESCRIPTION
nbd, just wanted to communicate the need for the `inclusive` argument.