### PR TITLE
Refactor remove to consume a promise

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -19,15 +19,16 @@ const intervalFn = function (chan, min) {
   let del = remove(config.get('slack_token'), chan)
   return function () {
     let latest = moment().subtract(min, 'minutes').unix()
+
     log(chan, 'deleting messages older than', latest)
 
-    return getHistory({
+    let hist = getHistory({
       token: config.get('slack_token'),
       channel: chan,
       latest: latest
     })
-      .then(del)
-      .catch(error)
+
+    return del(hist).catch(error)
   }
 }
 

--- a/src/remove.js
+++ b/src/remove.js
@@ -6,10 +6,14 @@ import debug from 'debug'
 const log = debug('ephembot:remove')
 log.log = console.log.bind(console)
 
-const postList = _.curry(function (token, channel, messages) {
-  log('initialized: ' + JSON.stringify(messages))
+const postList = _.curry(function (token, channel, history) {
+  log('initialized: ' + history)
 
-  return _.map(message => deleteMessage(token, channel, message), messages)
+  return history.then(function (messages) {
+    let removed = _.map(message => deleteMessage(token, channel, message), messages)
+
+    return Promise.all(removed)
+  })
 })
 
 const deleteMessage = function (token, channel, message) {

--- a/test/fixture/remove.fixture.js
+++ b/test/fixture/remove.fixture.js
@@ -61,4 +61,8 @@ const fixture = [
   }
 ]
 
-export default fixture
+const thePromise = new Promise(function (resolve) {
+  resolve(fixture)
+})
+
+export default thePromise

--- a/test/spec/remove.test.js
+++ b/test/spec/remove.test.js
@@ -16,6 +16,10 @@ const res = {
   'ts': 'stub'
 }
 
+const rej = {
+  'ok': false
+}
+
 describe('/remove', function () {
   beforeEach(function () {
     nock('https://slack.com').post('/api/chat.delete').times(40).reply(200, res)
@@ -29,14 +33,39 @@ describe('/remove', function () {
     expect(remove(token, channel) instanceof Function).to.be.equal(true)
   })
 
-  it('should return an array of promises when applied', function (done) {
+  it('should return a promises when applied', function (done) {
     let removed = remove(token, channel)(messages)
 
-    expect(removed instanceof Array).to.be.equal(true)
+    expect(removed instanceof Promise).to.be.equal(true)
+    done()
+  })
 
-    Promise.all(removed).then(function (res) {
-      expect(res.length).to.be.equal(10)
-      done()
+  it('should return a promise that, when fmapped, contain an array', function (done) {
+    let removed = remove(token, channel)(messages)
+
+    removed.then(function (messages) {
+      expect(messages instanceof Array).to.be.equal(true)
+      expect(messages.length).to.be.equal(10)
     })
+
+    done()
+  })
+})
+
+describe('/remove catch', function () {
+  beforeEach(function () {
+    nock('https://slack.com').post('/api/chat.delete').times(40).reply(200, rej)
+  })
+
+  afterEach(function () {
+    nock.cleanAll()
+  })
+
+  it('should return a promise that catches', function (done) {
+    let removed = remove(token, channel)(messages)
+
+    removed
+      .then(() => console.log('fail: this should\'nt be reachable'))
+      .catch(() => done())
   })
 })


### PR DESCRIPTION
This changes remove to operate on a promise, rather than an array. The reason being, it makes more sense to stay in promise land for as long as possible, rather then fmapping get_history's promise and then kicking off additional promise operations.

Addresses #25 